### PR TITLE
chore: group dependabot npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
     labels:
       - 'no-changelog'
     ignore:


### PR DESCRIPTION
This is to force dependabot to group all updates into one PR in npm